### PR TITLE
add enum description for 3PInverterData - and fix datatype bugs

### DIFF
--- a/FroniusSolarClient/Entities/SolarAPI/V1/InverterRealtimeData/CommonInverterData.cs
+++ b/FroniusSolarClient/Entities/SolarAPI/V1/InverterRealtimeData/CommonInverterData.cs
@@ -13,7 +13,7 @@ namespace FroniusSolarClient.Entities.SolarAPI.V1.InverterRealtimeData
         /// AC power 
         /// </summary>
         [JsonProperty("PAC")]
-        public UnitValue<int> AcPower { get; set; }
+        public UnitValue<decimal> AcPower { get; set; }
 
         /// <summary>
         /// AC current 

--- a/FroniusSolarClient/Entities/SolarAPI/V1/InverterRealtimeData/CumulationInverterData.cs
+++ b/FroniusSolarClient/Entities/SolarAPI/V1/InverterRealtimeData/CumulationInverterData.cs
@@ -15,7 +15,7 @@ namespace FroniusSolarClient.Entities.SolarAPI.V1.InverterRealtimeData
         /// AC power 
         /// </summary>
         [JsonProperty("PAC")]
-        public UnitValue<int> AcPower { get; set; }
+        public UnitValue<decimal> AcPower { get; set; }
 
         /// <summary>
         ///  Energy generated on current day 

--- a/FroniusSolarClient/Entities/SolarAPI/V1/InverterRealtimeData/DataCollection.cs
+++ b/FroniusSolarClient/Entities/SolarAPI/V1/InverterRealtimeData/DataCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 
 namespace FroniusSolarClient.Entities.SolarAPI.V1.InverterRealtimeData
@@ -9,6 +10,10 @@ namespace FroniusSolarClient.Entities.SolarAPI.V1.InverterRealtimeData
         CumulationInverterData,
         CommonInverterData,
         MinMaxInverterData,
+        /// <summary>
+        /// 3PInverterData, but Enum cannot start with number.
+        /// </summary>
+        [Description("3PInverterData")]
         P3InverterData
     }
 }

--- a/FroniusSolarClient/Extensions/EnumExtensions.cs
+++ b/FroniusSolarClient/Extensions/EnumExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace FroniusSolarClient.Extensions
+{
+    public static class EnumHelper
+    {
+        public static string GetDescription<T>(this T enumValue)
+            where T : struct, IConvertible
+        {
+            if (!typeof(T).IsEnum)
+                return null;
+
+            var description = enumValue.ToString();
+            var fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
+
+            if (fieldInfo != null)
+            {
+                var attrs = fieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), true);
+                if (attrs != null && attrs.Length > 0)
+                {
+                    description = ((DescriptionAttribute)attrs[0]).Description;
+                }
+            }
+
+            return description;
+        }
+    }
+}

--- a/FroniusSolarClient/Services/InverterRealtimeDataService.cs
+++ b/FroniusSolarClient/Services/InverterRealtimeDataService.cs
@@ -1,8 +1,7 @@
 ﻿using FroniusSolarClient.Entities.SolarAPI.V1;
 using FroniusSolarClient.Entities.SolarAPI.V1.InverterRealtimeData;
+using FroniusSolarClient.Extensions;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace FroniusSolarClient.Services
 {
@@ -13,11 +12,10 @@ namespace FroniusSolarClient.Services
     {
         private readonly string _cgi = "GetInverterRealtimeData.cgi";
 
-        public InverterRealtimeDataService(RestClient restClient) 
+        public InverterRealtimeDataService(RestClient restClient)
             : base(restClient)
         {
         }
-
 
         /// <summary>
         /// Builds the query string for the request
@@ -27,35 +25,34 @@ namespace FroniusSolarClient.Services
         protected string BuildQueryString(int deviceId, Scope scope, DataCollection dataCollection)
         {
             //TODO: Support list of string dictionary to build HTTP query string
-            return $"?Scope={scope}&DeviceId={deviceId}&DataCollection={dataCollection}";
+            return $"?Scope={scope}&DeviceId={deviceId}&DataCollection={dataCollection.GetDescription()}";
         }
 
         public Response<CumulationInverterData> GetCumulationInverterData(int deviceId = 1, Scope scope = Scope.Device)
         {
-            string baseEndpointURL = _cgi + BuildQueryString(deviceId, scope, DataCollection.CumulationInverterData);           
+            string baseEndpointURL = _cgi + BuildQueryString(deviceId, scope, DataCollection.CumulationInverterData);
             return GetDataServiceResponse<CumulationInverterData>(baseEndpointURL);
         }
 
         public Response<CommonInverterData> GetCommonInverterData(int deviceId = 1, Scope scope = Scope.Device)
         {
             string baseEndpointURL = _cgi + BuildQueryString(deviceId, scope, DataCollection.CommonInverterData);
-            return GetDataServiceResponse<CommonInverterData>(baseEndpointURL); 
+            return GetDataServiceResponse<CommonInverterData>(baseEndpointURL);
         }
 
-
-        public Response<P3InverterData> GetP3InverterData(int deviceId = 1, Scope scope = Scope.Device)
+        public Response<P3InverterData> Get3PInverterData(int deviceId = 1, Scope scope = Scope.Device)
         {
-            string param = $"?Scope={scope.ToString()}&DeviceId={deviceId}&DataCollection=P3InverterData";
-            string baseEndpointURL = _cgi + param;
+            string baseEndpointURL = _cgi + BuildQueryString(deviceId, scope, DataCollection.P3InverterData);
             return GetDataServiceResponse<P3InverterData>(baseEndpointURL);
         }
 
+        [Obsolete("use Get3PInverterData")]
+        public Response<P3InverterData> GetP3InverterData(int deviceId = 1, Scope scope = Scope.Device) => Get3PInverterData(deviceId, scope);
 
         public Response<MinMaxInverterData> GetMinMaxInverterData(int deviceId = 1, Scope scope = Scope.Device)
         {
             string baseEndpointURL = _cgi + BuildQueryString(deviceId, scope, DataCollection.MinMaxInverterData);
             return GetDataServiceResponse<MinMaxInverterData>(baseEndpointURL);
         }
-
     }
 }


### PR DESCRIPTION
I've just taken delivery of a Fronius Symo Gen24 6.0 and updated it's firmware to 1.19.7-1, I found these errors;

- fixes int -> decimal for datatype errors
- fixes 3P/P3 endpoint issue

Thanks!